### PR TITLE
Include linux binaries in PostgreSql.Binaries.Lite.nupkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ _ReSharper*/
 # ignore binaries from now on
 *.exe
 *.zip
+*.tar.gz
+packages
 pgsql
+linux
 *plv8jsbin_w64

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# PostgreSQL binaries for win64 lite
+# PostgreSQL binaries for win64 & linux64 lite
 
 Minimum set of binaries of the PostgreSQL database.
 
-The one in this file contains postgresql-10.6-1-windows-x64.zip without doc, include, pgAdmin 4, StackBuilder and symbols.
+The one in this file contains postgresql-10.6-1-windows-x64.zip, and postgresql-10.6-1-linux-x64.zip without doc, include, pgAdmin 4, StackBuilder and symbols.
 So, this package can be consumed from the unit tests.
 Sample commands to setup a database cluster would be:
 
@@ -99,4 +99,4 @@ task RunTests -depends Compile {
 ```
 
 ## License
-Scrips in this repository are subject to MIT license, PostgreSQL is licensed under: https://www.postgresql.org/about/licence/
+Scripts in this repository are subject to MIT license, PostgreSQL is licensed under: https://www.postgresql.org/about/licence/

--- a/build.ps1
+++ b/build.ps1
@@ -12,17 +12,23 @@ $nugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $filename = "postgresql-$($version)-windows-x64-binaries.zip"
 $download_url = "http://get.enterprisedb.com/postgresql/$filename"
 
+$linux_filename = "postgresql-$($version)-linux-x64-binaries.tar.gz"
+$linux_url = "http://get.enterprisedb.com/postgresql/$linux_filename"
+
 $plv8_filename = "pg10plv8jsbin_w64.zip"
 $plv8_url = "http://www.postgresonline.com/downloads/$($plv8_filename)"
 
 $base_package = "postgresql-$($version)-windows-x64-binaries-lite.zip"
+$linux_package = "postgresql-$($version)-linux-x64-binaries-lite.zip"
 $plv8_package = "postgresql-$($version)-windows-x64-binaries-lite-plv8.zip"
 
 # clean
 Write-Host "Cleaning..."
+if (Test-Path .\packages) { Remove-Item .\packages -Recurse -Force }
 if (Test-Path .\pgsql) { Remove-Item .\pgsql -Recurse -Force }
+if (Test-Path .\linux) { Remove-Item .\linux -Recurse -Force }
 if (Test-Path .\pg10plv8jsbin_w64) { Remove-Item .\pg10plv8jsbin_w64 -Recurse -Force }
-Remove-Item *.nupkg,*.exe,*.zip
+Remove-Item *.nupkg,*.exe,*.zip,*.tar.gz
 
 # download
 Write-Output "Downloading nuget.exe..."
@@ -30,6 +36,8 @@ Invoke-WebRequest -Uri $nugetUrl -OutFile "nuget.exe"
 
 Write-Output "Downloading $filename..."
 Invoke-WebRequest -Uri $download_url -OutFile $filename
+Write-Output "Downloading $linux_filename..."
+Invoke-WebRequest -Uri $linux_url -OutFile $linux_filename
 Write-Output "Downloading $plv8_filename..."
 Invoke-WebRequest -Uri $plv8_url -OutFile $plv8_filename
 
@@ -39,6 +47,17 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem
 Write-Output "Extracting $filename..."
 [System.IO.Compression.ZipFile]::ExtractToDirectory("$baseDir\$filename", "$baseDir\")
 
+Write-Output "Install SharpZipLib for tar.gz support..."
+Install-Package SharpZipLib -Destination packages -RequiredVersion 1.1.0
+Add-Type -Path "packages/SharpZipLib.1.1.0/lib/netstandard2.0/ICSharpCode.SharpZipLib.dll"
+
+Write-Output "Extracting $linux_filename..."
+$file = [IO.File]::OpenRead($linux_filename)
+$inStream = New-Object -TypeName ICSharpCode.SharpZipLib.GZip.GZipInputStream $file
+$tarIn = New-Object -TypeName ICSharpCode.SharpZipLib.Tar.TarInputStream $inStream
+$archive = [ICSharpCode.SharpZipLib.Tar.TarArchive]::CreateInputTarArchive($tarIn)
+$archive.ExtractContents("$baseDir\linux")
+
 Write-Output "Extracting $plv8_filename..."
 [System.IO.Compression.ZipFile]::ExtractToDirectory("$baseDir\$plv8_filename", "$baseDir\")
 
@@ -46,9 +65,16 @@ Write-Output "Extracting $plv8_filename..."
 Write-Host "Cleaning pgsql..."
 Get-ChildItem .\pgsql -Exclude bin,lib,share | Remove-Item -Recurse -Force
 
+Write-Host "Cleaning linux pgsql..."
+Get-ChildItem .\linux\pgsql -Exclude bin,lib,share | Remove-Item -Recurse -Force
+
 # packing archives
 Write-Output "Archiving $base_package"
 [System.IO.Compression.ZipFile]::CreateFromDirectory("$baseDir\pgsql", "$PSScriptRoot\$base_package", `
+    [System.IO.Compression.CompressionLevel]::Optimal, $true)
+
+Write-Output "Archiving $linux_package"
+[System.IO.Compression.ZipFile]::CreateFromDirectory("$baseDir\linux\pgsql", "$PSScriptRoot\$linux_package", `
     [System.IO.Compression.CompressionLevel]::Optimal, $true)
 
 Write-Output "Copying plv8 into pgsql..."

--- a/postgresql.binaries.lite.nuspec
+++ b/postgresql.binaries.lite.nuspec
@@ -27,5 +27,6 @@
     </metadata>
     <files>
         <file src="postgresql-*-windows-x64-binaries-lite.zip" target="content" />
+        <file src="postgresql-*-linux-x64-binaries-lite.zip" target="content" />
     </files>
 </package>


### PR DESCRIPTION
Given the increasing use of .Net on linux thanks to dotnet core, it would be useful to have this package including linux versions of postgresql as well as the windows binaries. That would allow us to easily take the same code we have on windows for starting local postgres instances up for testing and run it linux as well.